### PR TITLE
fix(FEC-13885): KMS v5.125.9| Webcast| "add/Cancel" presenters buttons appears one above each other instead of next to each other

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = (env, { mode }) => {
               options: {
                 esModule: true,
                 modules: {
-                  localIdentName: '[local]',
+                localIdentName: '[name]__[local]___[hash:base64:5]',
                   namedExport: true
                 }
               }


### PR DESCRIPTION
### Description of the Changes

Issue - css of Button component from common was not scoped, and affected any element on the page with class "button". This caused some kms buttons to have an incorrect style.

Fix - make the css classes under document player have scoped unique names.

Resolves FEC-13885


